### PR TITLE
Narrow bare excepts to Exception across the AL helpers

### DIFF
--- a/convert_spreadsheets_to_csv.py
+++ b/convert_spreadsheets_to_csv.py
@@ -373,7 +373,7 @@ class XLSProcessor(object):
 
             if recognizedOffice:
                 office = self.office_map[office]
-        except:
+        except Exception:
             print(f"Couldn't split contest '{contest}'")
 
         return (office, district)

--- a/file_download_unzipper.py
+++ b/file_download_unzipper.py
@@ -61,7 +61,7 @@ def unzip_zip_files(datadir, destination_path=None):
         try:
             with zipfile.ZipFile(zip_file,"r") as zip_ref:
                 zip_ref.extractall(zip_destination)
-        except:
+        except Exception:
             print(f"ERROR: Can't unzip {zip_file}")
 
 

--- a/src/total_checksum.py
+++ b/src/total_checksum.py
@@ -102,7 +102,7 @@ class TotalChecker(object):
 
 						if self.singleError:
 							break
-				except:
+				except Exception:
 					# If we can't find the total, just skip
 					# print(f'No file total available for {index}')
 					pass


### PR DESCRIPTION
flake8 E722. `file_download_unzipper`, `convert_spreadsheets_to_csv` and `total_checksum` had bare `except:` blocks around print-and-continue paths. Narrowed to `Exception` so KeyboardInterrupt isn't swallowed.